### PR TITLE
Refactor: Modernize frontend to ChatGPT-like design

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -6,10 +6,10 @@
 }
 
 body {
-  font-family: 'Roboto', 'Segoe UI', 'Helvetica Neue', sans-serif;
+  /* font-family will be inherited from index.css */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+  background: #f7f7f8; /* Solid light gray background */
   height: 100vh;
   width: 100vw;
   overflow-x: hidden;
@@ -45,7 +45,7 @@ body {
 /* Responsiva justeringar */
 @media (max-width: 768px) {
   body {
-    background: #f5f7fa;
+    background: #f7f7f8; /* Solid light gray background for mobile */
   }
   
   .App {
@@ -68,12 +68,12 @@ img {
 
 /* För code blocks i Markdown */
 pre {
-  background: #f8f9fa;
-  padding: 15px;
+  background: #f8f9fa; /* Light gray background for code blocks */
+  padding: 12px; /* Adjusted padding */
   border-radius: 8px;
   overflow-x: auto;
   margin: 10px 0;
-  border-left: 3px solid #4e73df;
+  border-left: 3px solid #007bff; /* New primary accent color */
 }
 
 code {
@@ -104,7 +104,7 @@ li {
 
 /* Huvudrubriker i Markdown */
 h1, h2, h3, h4, h5, h6 {
-  color: #2c3e50;
+  color: #333333; /* Neutral dark gray for headings */
   margin: 15px 0 10px 0;
 }
 

--- a/frontend/src/Components/ChatComponent.css
+++ b/frontend/src/Components/ChatComponent.css
@@ -4,13 +4,13 @@
     max-width: 1200px;
     width: 100%;
     margin: 0 auto;
-    padding: 20px;
-    font-family: 'Roboto', sans-serif;
+    padding: 10px; /* Reduced padding */
+    /* font-family will be inherited from index.css */
     display: flex;
     flex-direction: column;
     height: 100vh;
-    background: linear-gradient(135deg, #f5f7fa 0%, #e8ebf2 100%);
-    border-radius: 16px;
+    background: #f7f7f8; /* Solid light gray background */
+    border-radius: 0; /* Removed border-radius */
     box-sizing: border-box;
     overflow: hidden;
     position: relative;
@@ -21,18 +21,18 @@
   .chat-header {
     text-align: center;
     margin-bottom: 16px;
-    padding-bottom: 12px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    padding-bottom: 12px; /* This might be overridden by simplified padding below */
+    border-bottom: 1px solid #e0e0e0; /* Lighter border */
     flex-shrink: 0;
-    background-color: rgba(255, 255, 255, 0.8);
-    border-radius: 12px;
-    padding: 12px;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.03);
+    background-color: #f7f7f8; /* Match chat container background */
+    border-radius: 0; /* Removed border-radius */
+    padding: 15px 0; /* Simplified padding */
+    box-shadow: none; /* Removed shadow */
   }
   
   .chat-header h1 {
-    font-size: 1.8em;
-    color: #2c3e50;
+    font-size: 1.6em; /* Reduced font size */
+    color: #333333; /* Consistent dark gray for headings */
     margin: 0;
   }
   
@@ -47,11 +47,11 @@
     flex: 1 1 auto;
     overflow-y: auto;
     margin-bottom: 16px;
-    padding: 15px;
-    border-radius: 12px;
-    background-color: rgba(255, 255, 255, 0.5);
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.03);
-    backdrop-filter: blur(5px);
+    padding: 5px; /* Reduced padding */
+    border-radius: 0; /* Removed border-radius */
+    background-color: #ffffff; /* Lighter background */
+    box-shadow: none; /* Removed shadow */
+    /* backdrop-filter: blur(5px); Removed */
     scrollbar-width: thin;
     scrollbar-color: #c1c9d2 transparent;
     display: flex;
@@ -86,11 +86,11 @@
     margin-bottom: 15px;
     width: auto;
     max-width: 85%;
-    padding: 14px 16px;
-    border-radius: 18px;
+    padding: 10px 14px; /* Adjusted padding */
+    border-radius: 12px; /* Adjusted border-radius */
     line-height: 1.5;
     font-size: 1em;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+    box-shadow: none; /* Removed box-shadow */
     position: relative;
     word-wrap: break-word;
     white-space: pre-wrap;
@@ -147,23 +147,23 @@
   
   /* Glass effect for AI messages */
   .chat-message.assistant {
-    background: rgba(255, 255, 255, 0.85);
-    backdrop-filter: blur(8px);
-    border: 1px solid rgba(255, 255, 255, 0.6);
-    border-top-left-radius: 6px;
-    color: #2c3e50;
+    background: #ffffff; /* Simple, clean background */
+    /* backdrop-filter: blur(8px); Removed */
+    /* border: 1px solid rgba(255, 255, 255, 0.6); Removed */
+    /* border-top-left-radius: 6px; Removed for uniform radius */
+    color: #333333; /* Neutral dark gray for assistant text */
     align-self: flex-start;
     margin-left: 5px;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
   }
   
   .chat-message.user {
-    background: linear-gradient(135deg, #4e73df, #3a5dd0);
-    color: white;
+    background: #cce4ff; /* Muted accent color */
+    color: #2c3e50; /* Ensure text is readable */
     align-self: flex-end;
     margin-right: 5px;
-    border-top-right-radius: 6px;
-    box-shadow: 0 2px 8px rgba(78, 115, 223, 0.15);
+    /* border-top-right-radius: 6px; Removed for uniform radius */
+    box-shadow: none; /* Removed box-shadow */
     transition: transform 0.2s ease, box-shadow 0.2s ease;
   }
   
@@ -201,7 +201,7 @@
   .markdown-content h4 {
     margin: 1.2em 0 0.7em 0;
     line-height: 1.3;
-    color: #2c3e50;
+    color: #333333; /* Neutral dark gray for headings */
     font-weight: 600;
   }
   
@@ -258,20 +258,20 @@
   }
   
   .markdown-content a {
-    color: #4e73df;
+    color: #007bff; /* Use new primary accent color */
     text-decoration: underline;
     transition: color 0.2s ease;
   }
   
   .markdown-content a:hover {
-    color: #3a5dd0;
+    color: #0056b3; /* Darker shade of accent */
   }
   
   .markdown-content blockquote {
-    margin: 0.7em 0;
-    padding: 0.7em 1em;
-    border-left: 3px solid #e2e8f0;
-    background-color: rgba(237, 242, 247, 0.7);
+    margin: 10px 0; /* Consistent with pre, 0.7em was a bit small */
+    padding: 10px 15px; /* Adjusted padding */
+    border-left: 4px solid #007bff; /* New primary accent color and thickness */
+    background-color: #f0f0f0; /* Slightly more opaque light gray */
     color: #4a5568;
     border-radius: 4px;
   }
@@ -286,7 +286,7 @@
     display: inline-block;
     width: 8px;
     height: 16px;
-    background-color: #4e73df;
+    background-color: #007bff; /* Use new primary accent color */
     vertical-align: middle;
     margin-left: 2px;
     animation: blink 0.8s infinite;
@@ -366,7 +366,7 @@
     width: 8px;
     height: 8px;
     margin: 0 4px;
-    background-color: #4e73df;
+    background-color: #007bff; /* Use new primary accent color */
     border-radius: 50%;
     opacity: 0.7;
   }
@@ -394,10 +394,10 @@
     width: 100%;
     text-align: center;
     padding: 16px;
-    background-color: rgba(248, 249, 250, 0.7);
+    background-color: #ffffff; /* Cleaner background */
     border-radius: 10px;
-    border-left: 4px solid #4e73df;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.03);
+    border-left: 4px solid #007bff; /* New accent color */
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05); /* Subtler shadow */
     transition: all 0.3s ease;
     position: relative;
   }
@@ -417,14 +417,19 @@
     min-width: 100px !important;
     padding: 8px 16px !important;
     font-weight: 500 !important;
-    border-radius: 25px !important;
-    transition: transform 0.2s ease, box-shadow 0.2s ease !important;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.08) !important;
+    border-radius: 25px !important; /* Keep pill shape */
+    transition: background-color 0.2s ease, border-color 0.2s ease !important; /* Adjusted transition */
+    box-shadow: none !important; /* Removed default shadow */
+    background-color: #007bff !important; /* Primary accent color */
+    color: #ffffff !important; /* Text on accent */
+    border: 1px solid #007bff !important; /* Border with accent color */
   }
   
   .binary-option-btn:hover {
-    transform: translateY(-2px) !important;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15) !important;
+    /* transform: translateY(-2px) !important; Removed */
+    box-shadow: none !important; /* Ensure no shadow on hover */
+    background-color: #0069d9 !important; /* Darker accent on hover */
+    border-color: #0069d9 !important; /* Match background on hover */
   }
   
   /* Quick Response Buttons Styling */
@@ -445,35 +450,38 @@
   
   .quick-response-chip {
     font-size: 0.9rem !important;
-    border-radius: 20px !important;
-    transition: all 0.25s cubic-bezier(0.2, 0.8, 0.2, 1) !important;
+    border-radius: 20px !important; /* Keep pill shape */
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease !important; /* Adjusted transition */
     padding: 4px 2px 4px 10px !important;
     height: 38px !important;
-    border: 1px solid rgba(78, 115, 223, 0.5) !important;
-    background-color: rgba(255, 255, 255, 0.8) !important;
+    border: 1px solid #007bff !important; /* Accent color border */
+    background-color: #ffffff !important; /* White background */
+    color: #007bff !important; /* Accent color text */
     cursor: pointer !important;
-    will-change: transform, box-shadow, background-color !important;
-    transform: scale(1) translateZ(0) !important;
+    will-change: background-color, border-color, color; /* Adjusted will-change */
+    /* transform: scale(1) translateZ(0) !important; Removed */
   }
   
   .quick-response-chip:hover {
-    transform: translateY(-3px) scale(1.03) !important;
-    box-shadow: 0 6px 10px rgba(0, 0, 0, 0.15) !important;
-    background-color: rgba(255, 255, 255, 0.95) !important;
-    border-color: #4e73df !important;
+    /* transform: translateY(-3px) scale(1.03) !important; Removed */
+    box-shadow: none !important; /* Removed shadow */
+    background-color: #e7f3ff !important; /* Light accent shade for hover */
+    border-color: #007bff !important; /* Keep accent border on hover */
+    color: #007bff !important; /* Keep accent text on hover */
     z-index: 1 !important;
   }
   
   .quick-response-chip:active, .quick-response-active {
-    transform: translateY(0) scale(0.98) !important;
-    background-color: rgba(78, 115, 223, 0.1) !important;
-    border-color: #3a5dd0 !important;
-    box-shadow: 0 2px 3px rgba(0, 0, 0, 0.1) !important;
+    /* transform: translateY(0) scale(0.98) !important; Removed */
+    background-color: #d0e7ff !important; /* Slightly darker accent shade for active */
+    border-color: #0056b3 !important; /* Darker accent border for active */
+    color: #0056b3 !important; /* Darker accent text for active */
+    box-shadow: none !important; /* Removed shadow */
   }
   
   /* Ensure chip text is visible */
   .quick-response-chip span {
-    color: #2c3e50 !important;
+    color: inherit !important; /* Inherit color from parent .quick-response-chip */
     font-weight: 500 !important;
     white-space: nowrap !important;
   }
@@ -489,45 +497,55 @@
     align-items: center;
     gap: 12px;
     padding: 12px 16px;
-    background-color: white;
-    border-radius: 16px;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
+    background-color: #ffffff; /* Matches chat messages background */
+    border-radius: 0; /* Removed border-radius */
+    box-shadow: none; /* Removed shadow */
+    border-top: 1px solid #e0e0e0; /* Added top border for separation */
     flex-shrink: 0;
     margin-top: auto;
     transition: all 0.3s ease;
   }
   
   .input-area .MuiTextField-root {
-    background-color: #f8f9fa;
+    background-color: #ffffff; /* Cleaner background */
     border-radius: 12px;
     transition: all 0.3s ease;
   }
   
   .input-area .MuiTextField-root:focus-within {
     background-color: #fff;
-    box-shadow: 0 0 0 2px rgba(78, 115, 223, 0.1);
+    /* box-shadow: 0 0 0 2px rgba(78, 115, 223, 0.1); Removed for border highlight */
   }
   
   .input-area .MuiOutlinedInput-root {
     border-radius: 12px;
     transition: all 0.3s ease;
   }
+
+  .input-area .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline {
+    border-color: #d0d0d0; /* Light gray border for default state */
+  }
+
+  .input-area .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline {
+    border-color: #007bff; /* Primary accent color for focused state */
+    border-width: 1px; /* Subtle focus border */
+  }
   
   .input-area .MuiButton-root {
     border-radius: 12px;
-    background-color: #4e73df;
+    background-color: #007bff; /* Primary accent color */
     text-transform: none;
     font-weight: 600;
     padding: 10px 20px;
     transition: all 0.2s ease;
-    box-shadow: 0 4px 6px rgba(78, 115, 223, 0.2);
+    box-shadow: 0 2px 4px rgba(0, 123, 255, 0.2); /* Subtle shadow with accent color */
     white-space: nowrap;
   }
   
   .input-area .MuiButton-root:hover {
-    background-color: #3a5dd0;
-    transform: translateY(-2px);
-    box-shadow: 0 6px 8px rgba(78, 115, 223, 0.25);
+    background-color: #0056b3; /* Darker shade of accent color */
+    transform: none; /* Removed transform */
+    box-shadow: none; /* Removed shadow on hover */
   }
   
   .input-area .MuiButton-root:active {
@@ -539,11 +557,11 @@
     margin-top: 16px;
     padding: 16px;
     border-radius: 10px;
-    background-color: rgba(248, 249, 250, 0.7);
-    border-left: 4px solid #4e73df;
+    background-color: #ffffff; /* Cleaner background */
+    border-left: 4px solid #007bff; /* New accent color */
     width: 100%;
     box-sizing: border-box;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.03);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05); /* Subtler shadow */
     transition: all 0.3s ease;
     position: relative;
   }
@@ -570,22 +588,23 @@
   }
   
   .exercise-options .MuiButton-root {
-    border-radius: 8px;
+    border-radius: 8px !important; /* Standardized border radius */
     text-transform: none;
     font-weight: 500;
-    background-color: white;
-    color: #4e73df;
-    border: 1px solid #4e73df;
-    transition: all 0.2s ease;
+    background-color: #ffffff; /* White background */
+    color: #007bff; /* Accent color for text */
+    border: 1px solid #007bff; /* Accent color for border */
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease !important; /* Adjusted transition */
     margin-bottom: 6px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.03);
+    box-shadow: none !important; /* Removed default shadow */
   }
   
   .exercise-options .MuiButton-root:hover {
-    background-color: #4e73df;
-    color: white;
-    box-shadow: 0 4px 8px rgba(78, 115, 223, 0.2);
-    transform: translateY(-2px);
+    background-color: #e6f2ff !important; /* Light accent shade for hover */
+    color: #0056b3 !important; /* Darker accent text on hover */
+    border-color: #b3d7ff !important; /* Lighter accent border on hover */
+    box-shadow: none !important; /* Ensure no shadow on hover */
+    /* transform: translateY(-2px); Removed */
   }
   
   .suggestions-container {
@@ -602,16 +621,19 @@
     padding: 8px 16px !important;
     font-size: 0.9em !important;
     font-weight: 500 !important;
-    transition: all 0.2s ease !important;
-    background-color: #4e73df !important;
-    color: white !important;
-    box-shadow: 0 4px 6px rgba(78, 115, 223, 0.15) !important;
+    transition: background-color 0.2s ease, border-color 0.2s ease !important; /* Adjusted transition */
+    background-color: #007bff !important; /* Primary accent color */
+    color: #ffffff !important; /* Text on accent */
+    box-shadow: none !important; /* Removed default shadow */
     margin-bottom: 6px !important;
+    border: 1px solid #007bff !important; /* Ensure border for consistency */
   }
   
   .suggestion-button:hover {
-    transform: translateY(-2px) !important;
-    box-shadow: 0 6px 10px rgba(78, 115, 223, 0.25) !important;
+    /* transform: translateY(-2px) !important; Removed */
+    background-color: #0069d9 !important; /* Darker accent on hover */
+    border-color: #0069d9 !important; /* Match background on hover */
+    box-shadow: none !important; /* Ensure no shadow on hover */
   }
   
   /* Media elements */
@@ -641,7 +663,7 @@
     width: 50px;
     height: 50px;
     border-radius: 50%;
-    background: linear-gradient(135deg, #4e73df, #36b9cc);
+    background: #007bff; /* New primary accent color */
     display: flex;
     align-items: center;
     justify-content: center;
@@ -720,20 +742,20 @@
     margin: 10px 0;
     border-radius: 12px;
     overflow: hidden;
-    box-shadow: 0 6px 15px rgba(0, 0, 0, 0.06);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.05); /* Subtler shadow */
     background-color: #ffffff;
-    border-left: 4px solid #ff9800;
+    border-left: 4px solid #ff9800; /* Keeping orange for distinction */
     transition: all 0.3s ease;
     position: relative;
   }
   
   .scenario-card:hover {
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 10px rgba(0,0,0,0.08); /* Subtler hover shadow */
     transform: translateY(-2px);
   }
   
   .scenario-header {
-    background: linear-gradient(to right, #ff9800, #ffb74d);
+    background: linear-gradient(to right, #ff9800, #ffb74d); /* Keeping orange gradient for this header */
     color: white;
     padding: 12px 16px !important;
   }
@@ -764,10 +786,10 @@
   }
   
   .scenario-option-btn:hover {
-    background-color: #e9f0fe !important;
-    border-color: #4e73df !important;
-    transform: translateY(-2px);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08) !important;
+    background-color: #f0f0f0 !important; /* Slightly darker background on hover */
+    border-color: #e0e0e0 !important; /* Slightly darker border on hover */
+    /* transform: translateY(-2px); Removed */
+    box-shadow: none !important; /* Removed shadow on hover */
   }
   
   /* Multiple choice styling */
@@ -776,31 +798,31 @@
     margin: 10px 0;
     padding: 16px;
     border-radius: 12px;
-    background-color: #f9f9fc;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-    border-left: 4px solid #4e73df;
+    background-color: #ffffff; /* Cleaner background */
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05); /* Subtler shadow */
+    border-left: 4px solid #007bff; /* New accent color */
     transition: all 0.3s ease;
     position: relative;
   }
   
   .question-container:hover {
-    box-shadow: 0 6px 15px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.08); /* Subtler hover shadow */
   }
   
   .multiple-choice {
-    border-left-color: #4e73df;
+    border-left-color: #007bff; /* New accent color */
   }
   
   .matching-question {
-    border-left-color: #36b9cc;
+    border-left-color: #007bff; /* New accent color - can be varied if needed */
   }
   
   .ordering-question {
-    border-left-color: #1cc88a;
+    border-left-color: #007bff; /* New accent color - can be varied if needed */
   }
   
   .question-title {
-    color: #2c3e50;
+    color: #333333; /* Consistent dark gray for headings */
     margin-bottom: 14px !important;
     font-weight: 600;
     font-size: 1.05em !important;
@@ -808,12 +830,15 @@
   
   .question-submit-btn {
     margin-top: 15px !important;
-    transition: all 0.2s ease !important;
+    transition: background-color 0.2s ease, border-color 0.2s ease !important; /* Adjusted transition */
+    box-shadow: none !important; /* Removed default shadow */
+    border-radius: 8px !important; /* Standardized border radius */
   }
   
   .question-submit-btn:hover {
-    transform: translateY(-2px) !important;
-    box-shadow: 0 4px 8px rgba(78, 115, 223, 0.2) !important;
+    /* transform: translateY(-2px) !important; Removed */
+    box-shadow: none !important; /* Ensure no shadow on hover */
+    background-color: #0069d9 !important; /* Darker accent for hover */
   }
   
   /* Matching question styling */
@@ -832,7 +857,7 @@
   }
   
   .matching-item:hover {
-    background-color: rgba(78, 115, 223, 0.03);
+    background-color: rgba(0, 123, 255, 0.03); /* Hover with new accent shade */
   }
   
   .item-text {
@@ -853,8 +878,8 @@
   }
   
   .matching-select:focus {
-    border-color: #4e73df;
-    box-shadow: 0 1px 3px rgba(78, 115, 223, 0.2);
+    border-color: #007bff; /* New accent color */
+    box-shadow: 0 1px 3px rgba(0, 123, 255, 0.2); /* Shadow with new accent */
     outline: none;
   }
   
@@ -904,7 +929,7 @@
   }
   
   .roleplay-header {
-    background-color: #4e73df;
+    background-color: #007bff; /* New primary accent color */
     color: white;
     padding: 16px;
   }
@@ -931,7 +956,7 @@
   }
   
   .dialogue-user {
-    background-color: rgba(78, 115, 223, 0.05);
+    background-color: rgba(0, 123, 255, 0.05); /* Light shade of new accent */
     padding: 10px;
     border-radius: 8px;
   }
@@ -963,9 +988,9 @@
   }
   
   .learning-points {
-    background-color: #e9f0fe;
+    background-color: #e6f2ff; /* Lighter shade of new accent */
     padding: 16px;
-    border-top: 1px solid #dee2e6;
+    border-top: 1px solid #dee2e6; /* Keep or lighten border */
   }
   
   .learning-points-header {
@@ -989,13 +1014,14 @@
     width: 100%;
     margin: 12px 0 !important;
     border-radius: 8px !important;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05) !important;
+    background-color: #ffffff; /* Cleaner background */
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05) !important; /* Subtler shadow */
     transition: all 0.3s ease !important;
     position: relative;
   }
   
   .feedback-alert:hover {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08) !important;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.08) !important; /* Subtler hover shadow */
   }
   
   .feedback-content {
@@ -1089,10 +1115,13 @@
   
   /* Style for disabled suggestion buttons */
   .suggestions-container .suggestion-button[disabled] {
-    background-color: rgba(78, 115, 223, 0.7) !important;
-    color: rgba(255, 255, 255, 0.8) !important;
+    background-color: #e0e0e0 !important; /* Light gray background */
+    color: #a0a0a0 !important; /* Medium gray text */
+    border-color: #e0e0e0 !important; /* Match background */
     box-shadow: none !important;
     transform: none !important;
+    opacity: 0.7 !important; /* General opacity for disabled */
+    cursor: default !important;
   }
   
   /* Prevent hover effects on disabled elements */
@@ -1131,7 +1160,7 @@
   }
   
   .disabled-roleplay .roleplay-header {
-    background-color: #6c8ae4 !important;
+    background-color: #66aaff !important; /* Lighter shade of new accent for disabled */
   }
   
   .disabled-binary-question .binary-options {
@@ -1175,9 +1204,13 @@
   /* Responsive adjustments */
   @media (max-width: 768px) {
     .chat-container {
-      padding: 15px;
-      height: calc(100vh - 30px);
+      padding: 15px; /* Keep slightly more padding for tablet */
+      height: calc(100vh - 30px); /* This seems to be a specific adjustment, keep if needed */
       border-radius: 0;
+    }
+
+    .chat-messages {
+      padding: 10px; /* Ensure messages area has some padding on tablet */
     }
     
     .chat-message {
@@ -1256,7 +1289,11 @@
   /* For very small screens */
   @media (max-width: 480px) {
     .chat-container {
-      padding: 10px;
+      padding: 10px; /* Consistent with desktop reduction */
+    }
+
+    .chat-messages {
+      padding: 10px; /* Ensure messages area has some padding on small mobile */
     }
     
     .chat-message {

--- a/frontend/src/Components/ChatComponent.js
+++ b/frontend/src/Components/ChatComponent.js
@@ -452,8 +452,8 @@ const QuickResponseButtons = ({ onSendQuickResponse, disabled }) => {
   const [activeIndex, setActiveIndex] = useState(null);
   const quickResponses = [
     { text: "Berätta mer om detta", icon: "🔍" },
-    { text: "Jag förstår inte", icon: "❓" },
-    { text: "Fortsätt", icon: "➡️" }
+    { text: "Jag förstår inte", icon: "❓" }
+    // { text: "Fortsätt", icon: "➡️" } // Removed as per instructions
   ];
 
   const handleClick = (text, index) => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,8 +1,6 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
This commit applies a significant visual refresh to the chat interface, aiming for a cleaner, more modern, and minimalist aesthetic inspired by ChatGPT.

Key changes include:
- Simplified Color Palette: Replaced gradients with solid light gray backgrounds (#f7f7f8) and introduced a primary accent color (#007bff) for interactive elements.
- Refined Typography: Updated the font stack to a modern sans-serif selection and standardized heading colors (#333333) and sizes for better readability.
- Streamlined Message Styling: Removed shadows and adjusted border-radius/padding for chat messages. Updated code block and blockquote styles.
- Modernized Interactive Elements: Flattened button styles, refined input field appearance, and updated quick response chip styling. Removed 'Fortsätt' quick response button.
- Improved Layout & Spacing: Reduced container padding, removed unnecessary border-radius and shadows from main layout blocks, and ensured a minimalistic header.
- Consistency: Addressed minor inconsistencies found during review to ensure a cohesive user experience across different screen sizes.